### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # bipbop-xml-schema
-Repositório de schemas BIPBOP.
+O Poder Judiciário sofre com a falta de padronização nos dados em todos os tribunais do País. Onde, na maior parte do tempo é gasto com obtenção, organização e limpeza dos dados. 
+
+A Bipbop especializada na captura de dados em todos os tribunais do Brasil e sendo referência no mercado juridico. Elaborou um documento de estrutura de dados que contempla essa variedade de ocorrências (XSD). 
+
+ O XSD, XML Schema Definition, é um arquivo padrão XML que contém a estrutura, tipos de dados e regras de validação dos elementos presentes dentro de um arquivo XML. 
+
+ 
+ ![estrutura_](https://user-images.githubusercontent.com/35104558/79240604-61191400-7e48-11ea-9b44-cef58c38d7f1.png)
+
+
+
+
+Você vai perceber que o XML schema foi  detalhado cada campo/tag da estrutura e as validações que foram consideradas. 
+
+Este repositório de schemas é o resultado desse trabalho.


### PR DESCRIPTION
# bipbop-xml-schema
O Poder Judiciário sofre com a falta de padronização nos dados em todos os tribunais do País. Onde, na maior parte do tempo é gasto com obtenção, organização e limpeza dos dados. 

A Bipbop especializada na captura de dados em todos os tribunais do Brasil e sendo referência no mercado juridico. Elaborou um documento de estrutura de dados que contempla essa variedade de ocorrências (XSD). 

 O XSD, XML Schema Definition, é um arquivo padrão XML que contém a estrutura, tipos de dados e regras de validação dos elementos presentes dentro de um arquivo XML. 

 
 ![estrutura_](https://user-images.githubusercontent.com/35104558/79240604-61191400-7e48-11ea-9b44-cef58c38d7f1.png)


Você vai perceber que o XML schema foi  detalhado cada campo/tag da estrutura e as validações que foram consideradas. 

Este repositório de schemas é o resultado desse trabalho.